### PR TITLE
Fix style of blocks and markers when default skin is not used

### DIFF
--- a/app/controllers/macros_controller.rb
+++ b/app/controllers/macros_controller.rb
@@ -2,8 +2,8 @@ class MacrosController < ApplicationController
     layout 'admin'
     menu_item :custom_macros
 
-    before_filter :require_admin
-    before_filter :find_macro, :only => [ :edit, :update, :destroy ]
+    before_action :require_admin
+    before_action :find_macro, :only => [ :edit, :update, :destroy ]
 
     def index
         @macros = WikiMacro.order(:name)
@@ -14,7 +14,7 @@ class MacrosController < ApplicationController
     end
 
     def create
-        @macro = WikiMacro.new(params[:wiki_macro])
+        @macro = WikiMacro.new(macro_params)
         if request.post? && @macro.save
             flash[:notice] = l(:notice_successful_create)
             @macro.register!
@@ -30,7 +30,7 @@ class MacrosController < ApplicationController
     def update
         if request.patch?
             old_name = @macro.name
-            @macro.attributes = params[:wiki_macro]
+            @macro.attributes = macro_params
             name_changed = @macro.name_changed?
             desc_changed = @macro.description_changed?
             if @macro.save
@@ -59,6 +59,9 @@ class MacrosController < ApplicationController
     end
 
 private
+    def macro_params
+        params.require(:wiki_macro).permit(:name, :description, :content)
+    end
 
     def find_macro
         @macro = WikiMacro.find(params[:id])

--- a/app/controllers/mentions_controller.rb
+++ b/app/controllers/mentions_controller.rb
@@ -1,8 +1,8 @@
 class MentionsController < ApplicationController
     include ApplicationHelper
 
-    before_filter :find_user,               :only => :index
-    before_filter :find_object_and_project, :only => :autocomplete
+    before_action :find_user,               :only => :index
+    before_action :find_object_and_project, :only => :autocomplete
 
     def index
         count = 0

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -2,8 +2,6 @@ class Mention < ActiveRecord::Base
     belongs_to :mentioned, :class_name => 'User'
     belongs_to :mentioning, :polymorphic => true
 
-    attr_protected :id
-
     before_save  :set_created_on
     after_create :send_notification
 

--- a/app/models/wiki_macro.rb
+++ b/app/models/wiki_macro.rb
@@ -11,8 +11,6 @@ class WikiMacro < ActiveRecord::Base
 
     validate :validate_name
 
-    attr_protected :id
-
     MACRO_ARGUMENT_RE = %r{%(url)?(?:\{([^{=}]*)\}|\[([0-9]*)\]|\((\**)\))}
 
     def to_s

--- a/assets/stylesheets/wiking.css
+++ b/assets/stylesheets/wiking.css
@@ -13,13 +13,19 @@ span.wiking-hidden {
     opacity: 0.25;
     filter: alpha(opacity=25);
 }
+div.wiking {
+    background-repeat: no-repeat;
+}
 div.wiking.flash {
-    border-width: 1px;
     background-position: 6px 6px;
     width: auto;
     overflow-x: auto;
     overflow-y: hidden;
-    font-size: 10pt;
+    font-size: 1.1em;
+    padding: 6px 4px 6px 30px;
+    margin-bottom: 12px;
+    border: 1px solid;
+    border-radius: 3px
 }
 div.wiking.warning {
     background-image: url(../images/warning.png);
@@ -28,19 +34,16 @@ div.wiking.warning {
 div.wiking.notice {
     background-image: url(../images/notice.png);
     background-position: 6px 4px;
-    background-repeat: no-repeat;
     background-color: #c5e7f8;
     border-color: #759fcf;
     color: #00365f;
 }
 div.wiking.tip {
     background-image: url(../images/tip.png);
-    background-repeat: no-repeat;
     background-color: #eee;
     border-color: #bbb;
 }
 span.wiking.marker {
-    background-repeat: no-repeat;
     display: inline-block;
 }
 span.wiking.marker-left,

--- a/init.rb
+++ b/init.rb
@@ -6,56 +6,56 @@ Rails.logger.info 'Starting WikiNG Plugin for Redmine'
 
 Rails.configuration.to_prepare do
     unless Redmine::WikiFormatting::Textile::Formatter.included_modules.include?(WikingFormatterPatch)
-        Redmine::WikiFormatting::Textile::Formatter.send(:include, WikingFormatterPatch)
+        Redmine::WikiFormatting::Textile::Formatter.send(:prepend, WikingFormatterPatch)
     end
     unless Redmine::WikiFormatting::Textile::Helper.included_modules.include?(WikingWikiHelperPatch)
-        Redmine::WikiFormatting::Textile::Helper.send(:include, WikingWikiHelperPatch)
+        Redmine::WikiFormatting::Textile::Helper.send(:prepend, WikingWikiHelperPatch)
     end
     unless Redmine::WikiFormatting::Macros::Definitions.included_modules.include?(WikingMacrosDefinitionsPatch)
-        Redmine::WikiFormatting::Macros::Definitions.send(:include, WikingMacrosDefinitionsPatch)
+        Redmine::WikiFormatting::Macros::Definitions.send(:prepend, WikingMacrosDefinitionsPatch)
     end
     unless ApplicationHelper.included_modules.include?(WikingApplicationHelperPatch)
-        ApplicationHelper.send(:include, WikingApplicationHelperPatch)
+        ApplicationHelper.send(:prepend, WikingApplicationHelperPatch)
     end
 
     unless Redmine::Export::PDF::ITCPDF.included_modules.include?(WikingPDFPatch)
-        Redmine::Export::PDF::ITCPDF.send(:include, WikingPDFPatch)
+        Redmine::Export::PDF::ITCPDF.send(:prepend, WikingPDFPatch)
     end
 
     unless JournalsController.included_modules.include?(WikingLlControllerPatch)
-        JournalsController.send(:include, WikingLlControllerPatch)
+        JournalsController.send(:prepend, WikingLlControllerPatch)
     end
     unless MessagesController.included_modules.include?(WikingLlControllerPatch)
-        MessagesController.send(:include, WikingLlControllerPatch)
+        MessagesController.send(:prepend, WikingLlControllerPatch)
     end
     unless CommentsController.included_modules.include?(WikingCommentsControllerPatch)
-        CommentsController.send(:include, WikingCommentsControllerPatch)
+        CommentsController.send(:prepend, WikingCommentsControllerPatch)
     end
 
     unless User.included_modules.include?(WikingUserPatch)
-        User.send(:include, WikingUserPatch)
+        User.send(:prepend, WikingUserPatch)
     end
 
     unless WikiContent.included_modules.include?(WikingContentPatch)
-        WikiContent.send(:include, WikingContentPatch)
+        WikiContent.send(:prepend, WikingContentPatch)
     end
     unless Comment.included_modules.include?(WikingCommentPatch)
-        Comment.send(:include, WikingCommentPatch)
+        Comment.send(:prepend, WikingCommentPatch)
     end
     unless Journal.included_modules.include?(WikingJournalPatch)
-        Journal.send(:include, WikingJournalPatch)
+        Journal.send(:prepend, WikingJournalPatch)
     end
 
     unless Redmine::Notifiable.included_modules.include?(WikingNotifiablePatch)
-        Redmine::Notifiable.send(:include, WikingNotifiablePatch)
+        Redmine::Notifiable.send(:prepend, WikingNotifiablePatch)
     end
     unless Mailer.included_modules.include?(WikingMailerPatch)
-        Mailer.send(:include, WikingMailerPatch)
+        Mailer.send(:prepend, WikingMailerPatch)
     end
 
     for model in [ Issue, Journal ]
         unless Issue.included_modules.include?(WikingNotifiedUsersPatch)
-            Issue.send(:include, WikingNotifiedUsersPatch)
+            Issue.send(:prepend, WikingNotifiedUsersPatch)
         end
     end
 end

--- a/lib/wiking_comment_patch.rb
+++ b/lib/wiking_comment_patch.rb
@@ -2,9 +2,9 @@ require_dependency 'comment'
 
 module WikingCommentPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
-        base.send(:include, VisibleMethod) unless base.method_defined?(:visible?)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
+        base.send(:prepend, VisibleMethod) unless base.method_defined?(:visible?)
         base.class_eval do
             unloadable
         end

--- a/lib/wiking_comments_controller_patch.rb
+++ b/lib/wiking_comments_controller_patch.rb
@@ -2,8 +2,8 @@ require_dependency 'comments_controller'
 
 module WikingCommentsControllerPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
         end

--- a/lib/wiking_content_patch.rb
+++ b/lib/wiking_content_patch.rb
@@ -2,8 +2,8 @@ require_dependency 'wiki_content'
 
 module WikingContentPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
         end

--- a/lib/wiking_formatter_patch.rb
+++ b/lib/wiking_formatter_patch.rb
@@ -2,9 +2,9 @@ require_dependency 'redmine/wiki_formatting/textile/formatter'
 
 module WikingFormatterPatch
 
-    def self.included(base)
-        base.extend(ClassMethods)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.prepend(ClassMethods)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             include Redmine::I18n
 

--- a/lib/wiking_journal_patch.rb
+++ b/lib/wiking_journal_patch.rb
@@ -2,8 +2,8 @@ require_dependency 'journal'
 
 module WikingJournalPatch
 
-    def self.included(base)
-        base.send(:include, VisibleMethod) unless base.method_defined?(:visible?)
+    def self.prepended(base)
+        base.send(:prepend, VisibleMethod) unless base.method_defined?(:visible?)
         base.class_eval do
             unloadable
         end

--- a/lib/wiking_ll_controller_patch.rb
+++ b/lib/wiking_ll_controller_patch.rb
@@ -3,8 +3,8 @@ require_dependency 'messages_controller'
 
 module WikingLlControllerPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
         end

--- a/lib/wiking_macros_definitions_patch.rb
+++ b/lib/wiking_macros_definitions_patch.rb
@@ -2,20 +2,20 @@ require_dependency 'redmine/wiki_formatting/macros'
 
 module WikingMacrosDefinitionsPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
 
-            alias_method_chain :macro_exists?, :custom
-            alias_method_chain :exec_macro,    :custom
+            # alias_method_chain :macro_exists?, :custom
+            # alias_method_chain :exec_macro,    :custom
         end
     end
 
     module InstanceMethods
 
-        def macro_exists_with_custom?(name)
-            exists = macro_exists_without_custom?(name)
+        def macro_exists?(name)
+            exists = super?(name)
             unless exists
                 if macro = WikiMacro.find_by_name(name)
                     macro.register!
@@ -25,7 +25,7 @@ module WikingMacrosDefinitionsPatch
             exists
         end
 
-        def exec_macro_with_custom(*args)
+        def exec_macro(*args)
             method_name = "macro_#{args[0].downcase}"
             unless respond_to?(method_name)
                 macro = WikiMacro.find_by_name(args[0])
@@ -36,7 +36,7 @@ module WikingMacrosDefinitionsPatch
                     macro.register! unless Redmine::WikiFormatting::Macros.available_macros.has_key?(macro.name.to_sym)
                 end
             end
-            exec_macro_without_custom(*args)
+            super(*args)
         end
 
     end

--- a/lib/wiking_mailer_patch.rb
+++ b/lib/wiking_mailer_patch.rb
@@ -2,31 +2,31 @@ require_dependency 'mailer'
 
 module WikingMailerPatch
 
-    def self.included(base)
-        base.extend(ClassMethods)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.prepend(ClassMethods)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
 
-            class << self
-                alias_method_chain :deliver_issue_add,  :mentions
-                alias_method_chain :deliver_issue_edit, :mentions
-            end
+            # class << self
+            #     alias_method_chain :deliver_issue_add,  :mentions
+            #     alias_method_chain :deliver_issue_edit, :mentions
+            # end
         end
     end
 
     module ClassMethods
 
-        def deliver_issue_add_with_mentions(issue)
+        def deliver_issue_add(issue)
             begin
                 view_context_class.new.textilizable(issue, :description)
             rescue
             end
 
-            deliver_issue_add_without_mentions(issue)
+            super(issue)
         end
 
-        def deliver_issue_edit_with_mentions(journal)
+        def deliver_issue_edit(journal)
             if journal.notes?
                 begin
                     view_context_class.new.textilizable(journal, :notes)
@@ -34,7 +34,7 @@ module WikingMailerPatch
                 end
             end
 
-            deliver_issue_edit_without_mentions(journal)
+            super(journal)
         end
 
     end

--- a/lib/wiking_notifiable_patch.rb
+++ b/lib/wiking_notifiable_patch.rb
@@ -1,20 +1,17 @@
 module WikingNotifiablePatch
 
-    def self.included(base)
-        base.extend(ClassMethods)
+    def self.prepended(base)
+        base.prepend(ClassMethods)
         base.class_eval do
             unloadable
 
-            class << self
-                alias_method_chain :all, :wiking
-            end
         end
     end
 
     module ClassMethods
 
-        def all_with_wiking
-            notifications = all_without_wiking
+        def all
+            notifications = super
             notifications << Redmine::Notifiable.new('user_mentioned')
             notifications
         end

--- a/lib/wiking_notified_users_patch.rb
+++ b/lib/wiking_notified_users_patch.rb
@@ -1,27 +1,26 @@
 module WikingNotifiedUsersPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
 
             has_many :mentions, :as => :mentioning, :inverse_of => :mentioning, :dependent => :delete_all
             has_many :mentioned_users, :through => :mentions, :source => :mentioned
 
-            alias_method_chain :notified_users, :mentioned_users
         end
     end
 
     module InstanceMethods
 
-        def notified_users_with_mentioned_users
+        def notified_users
             if is_a?(Journal)
                 notified = journalized.notified_users_without_mentioned_users
                 if private_notes?
                     notified.reject!{ |user| !user.allowed_to?(:view_private_notes, journalized.project) }
                 end
             else
-                notified = notified_users_without_mentioned_users
+                notified = super
             end
             mentioned = mentioned_users.to_a
             if mentioned.any?

--- a/lib/wiking_pdf_patch.rb
+++ b/lib/wiking_pdf_patch.rb
@@ -2,19 +2,18 @@ require_dependency 'redmine/export/pdf'
 
 module WikingPDFPatch
 
-    def self.included(base)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
 
-            alias_method_chain :formatted_text, :wiking
         end
     end
 
     module InstanceMethods
 
-        def formatted_text_with_wiking(text)
-            html = formatted_text_without_wiking(text)
+        def formatted_text(text)
+            html = super(text)
 
             html.gsub!(%r{<span class="wiking (marker|smiley) [^"]+" title="([^"]+)"></span>}) do |match|
                 type, title = $1, $2

--- a/lib/wiking_user_patch.rb
+++ b/lib/wiking_user_patch.rb
@@ -2,8 +2,8 @@ require_dependency 'user'
 
 module WikingUserPatch
 
-    def self.included(base)
-        base.extend(ClassMethods)
+    def self.prepended(base)
+        base.prepend(ClassMethods)
         base.class_eval do
             unloadable
         end

--- a/lib/wiking_wiki_helper_patch.rb
+++ b/lib/wiking_wiki_helper_patch.rb
@@ -2,14 +2,12 @@ require_dependency 'redmine/wiki_formatting/textile/helper'
 
 module WikingWikiHelperPatch
 
-    def self.included(base)
-        base.extend(ClassMethods)
-        base.send(:include, InstanceMethods)
+    def self.prepended(base)
+        base.prepend(ClassMethods)
+        base.send(:prepend, InstanceMethods)
         base.class_eval do
             unloadable
 
-            alias_method_chain :heads_for_wiki_formatter, :wiking
-            alias_method_chain :wikitoolbar_for,          :wiking
         end
     end
 
@@ -18,8 +16,8 @@ module WikingWikiHelperPatch
 
     module InstanceMethods
 
-        def heads_for_wiki_formatter_with_wiking
-            heads_for_wiki_formatter_without_wiking
+        def heads_for_wiki_formatter
+            super
 
             unless @wiking_heads_for_wiki_formatter_included
                 content_for :header_tags do
@@ -37,8 +35,8 @@ module WikingWikiHelperPatch
             end
         end
 
-        def wikitoolbar_for_with_wiking(field_id)
-            wikitoolbar_for_without_wiking(field_id) +
+        def wikitoolbar_for(field_id, preview_url = preview_text_path)
+            super(field_id, preview_url) +
             javascript_tag(render(:partial => 'autocomplete/wiking.js', :locals => { :field_id => field_id }))
         end
 


### PR DESCRIPTION
When the default skin is not used, not all default styles are available, thus causing background images to repeat and not show the borders of the flash.

Set font-size same as application.css of Redmine.